### PR TITLE
feat: build schema, inject into Wasm

### DIFF
--- a/build_workspace/Cargo.lock
+++ b/build_workspace/Cargo.lock
@@ -53,7 +53,14 @@ dependencies = [
  "glob",
  "serde",
  "toml",
+ "walrus",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "glob"
@@ -62,12 +69,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.29"
+name = "heck"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
- "unicode-xid",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -81,18 +118,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -101,13 +138,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -120,7 +157,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "unicode-ident"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+
+[[package]]
+name = "walrus"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb08e48cde54c05f363d984bb54ce374f49e242def9468d2e1b6c2372d291f8"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "leb128",
+ "log",
+ "walrus-macro",
+ "wasmparser",
+]
+
+[[package]]
+name = "walrus-macro"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.77.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b35c86d22e720a07d954ebbed772d01180501afe7d03d464f413bb5f8914a8d6"

--- a/build_workspace/Cargo.lock
+++ b/build_workspace/Cargo.lock
@@ -3,9 +3,53 @@
 version = 3
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+
+[[package]]
+name = "brotli"
+version = "3.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "build_workspace"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "brotli",
  "glob",
  "serde",
  "toml",

--- a/build_workspace/Cargo.toml
+++ b/build_workspace/Cargo.toml
@@ -10,3 +10,9 @@ publish = false
 toml = "0.4.2"
 serde = { version = "1.0.130", features = ["derive"] }
 glob = "0.3.0"
+
+## Utilities
+brotli = {version= "3.3.4", features = ["std"] }
+
+## Errors
+anyhow = "1.0.51"

--- a/build_workspace/Cargo.toml
+++ b/build_workspace/Cargo.toml
@@ -13,6 +13,7 @@ glob = "0.3.0"
 
 ## Utilities
 brotli = {version= "3.3.4", features = ["std"] }
+walrus = "0.19.0" # tools for working with Wasm
 
 ## Errors
 anyhow = "1.0.51"

--- a/build_workspace/src/ext.rs
+++ b/build_workspace/src/ext.rs
@@ -1,0 +1,17 @@
+use anyhow::{Context, Result};
+use std::{fs, path::Path};
+
+pub fn compress_file(p: &Path) -> Result<Vec<u8>> {
+    let buf = fs::read(p)
+        .map_err(anyhow::Error::from)
+        .with_context(|| format!("{}", p.to_string_lossy()))?
+        .into_boxed_slice();
+    let mut out = Vec::<u8>::new();
+    let params = brotli::enc::BrotliEncoderParams {
+        quality: 11,
+        ..Default::default()
+    };
+
+    brotli::BrotliCompress(&mut buf.as_ref(), &mut out, &params)?;
+    Ok(out)
+}

--- a/build_workspace/src/lib.rs
+++ b/build_workspace/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod ext;

--- a/build_workspace/src/main.rs
+++ b/build_workspace/src/main.rs
@@ -102,19 +102,20 @@ fn main() -> Result<()> {
         let mut module = Module::from_file(input.clone())?;
         module.customs.add(RawCustomSection {
             name: "schema".to_string(),
-            data,
+            data: data.clone(),
         });
         println!(
             "     updating in place: {}",
             input.clone().to_string_lossy()
         );
+        println!("     compressed schema size:    {:>4}kB", data.len() / 1024);
         println!(
-            "     original size:           {}kB",
+            "     original Wasm size:        {:>4}kB",
             fs::metadata(input.clone())?.len() / 1024
         );
         module.emit_wasm_file(input.clone())?;
         println!(
-            "     with schema, compressed: {}kB",
+            "     Wasm with injected schema: {:>4}kB",
             fs::metadata(input)?.len() / 1024
         );
     }


### PR DESCRIPTION
Wouldn't it be great to always have schemas available right on-chain?

Then tooling can plug right in. Tools like [ts-codegen](https://github.com/CosmWasm/ts-codegen) can build TS wrappers for on-chain contracts. Frontends like [RAEN Admin](https://raen.dev/admin) can generate interactive docs. You can build interactive CLIs for specific deployed contracts. Imagine!

Perhaps this hasn't been done out of fear of bloating the size of deployed Wasm files. But if we compress the JSON with [brotli](https://docs.rs/brotli), it ends up adding just a tiny number of kB for most contracts. The largest compressed schemas in the cw-plus repo weigh in at 6kB, for the multisig contracts. That's 6kB on (uncompressed) contracts weighing in at 343kB (fixed multisig) and 438kB (flex multisig). Not bad!

Since the point here is to only keep around schema'd Wasms, I just decided to update in-place. We could keep the old un-schema'd files around, though, if y'all prefer.

To do
-----

- [ ] Single contracts, not just workspaces (honestly not sure why there are two scripts in the first place; we can do it all with Rust, get rid of the bash scripts, and make it check if root `Cargo.toml` defines `members` or not).
- [ ] Possibly make file-lookup logic more robust (currently hard-coding paths to built binaries, rather than using a library to do it, and have only tested on macOS)
- [ ] Demonstrate hooking into this with an adapted version of [RAEN Admin](https://raen.dev/admin) — this already grabs an on-chain schema [out of a Wasm custom section and decompresses it with brotli](https://github.com/raendev/admin/blob/0a4b9c6ff509425bceea5e9408ea2aea51e1f42c/src/near/schema.ts#L62-L79), but for NEAR, and the CosmWasm schema is a different shape than what the [react json-schema form](https://www.npmjs.com/package/@rjsf/core) component consumes, so some translation is necessary.
- [ ] Add tests
- [ ] Don't panic/abort if project doesn't have a `schema` binary / alias. In these cases, just don't add the schema.
- [ ] Version the schema. That is, embed version info into the schema or into the Wasm custom section name, so consumers can decode it correctly even as the schema format continues to evolve.