### PR TITLE
Small Readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ This has been tested on Linux (Ubuntu / Debian). There are currently versions of
 architectures: Intel/Amd 64-bits, and Arm 64-bits (these run natively on Mac M1 machines).
 
 **However**, the native Arm version produces different wasm artifacts than the Intel version. Given that that impacts
-reproducibility, non-Intel images contain a "-arm64" suffix and build artifacts contain "-aarch64" suffix, to differentiate and flag them.
+reproducibility, non-Intel images contain a "-arm64" suffix and build artifacts contain a "-aarch64" suffix, to differentiate and flag them.
 
 Arm images are released to ease development and testing on Mac M1 machines. **For release / production use,
 only contracts built with the Intel optimizers must be used.**

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ This has been tested on Linux (Ubuntu / Debian). There are currently versions of
 architectures: Intel/Amd 64-bits, and Arm 64-bits (these run natively on Mac M1 machines).
 
 **However**, the native Arm version produces different wasm artifacts than the Intel version. Given that that impacts
-reproducibility, non-Intel images and build artifacts contain a "-arm64" suffix, to differentiate and flag them.
+reproducibility, non-Intel images contain a "-arm64" suffix and build artifacts contain "-aarch64" suffix, to differentiate and flag them.
 
 Arm images are released to ease development and testing on Mac M1 machines. **For release / production use,
 only contracts built with the Intel optimizers must be used.**


### PR DESCRIPTION
Noticed in readme that it says about "-arm64" suffix of build artifacts, but it's "-aarch64". Checked latest arm64 CI job to confirm: https://app.circleci.com/pipelines/github/CosmWasm/rust-optimizer/288/workflows/d1226c7e-c41c-488f-9acd-ae58058961f5/jobs/942/steps?invite=true#step-108-15862_24