### PR TITLE
Update to Rust 1.86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Bump Rust to 1.86.0
+
 ## [0.16.1] - 2024-10-11
 
 - Bump Rust to current stable 1.81.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [Unreleased]
 
-- Bump Rust to 1.86.0
+- Bump Rust to 1.86.0.
+  Note that contracts built with this version require CosmWasm 3.0+ on the chain and cannot be
+  uploaded to chains running lower versions.
 
 ## [0.16.1] - 2024-10-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## [Unreleased]
 
-- Bump Rust to 1.86.0.
-  Note that contracts built with this version require CosmWasm 3.0+ on the chain and cannot be
-  uploaded to chains running lower versions.
+- Bump Rust to 1.86.0. ([#168])
+- Remove `--signext-lowering` flag from `wasm-opt`. ([#168])
+
+Note that contracts built with this version _require CosmWasm 3.0+_ on the chain and cannot be
+uploaded to chains running lower versions.
+
+[#168]: https://github.com/CosmWasm/optimizer/pull/168
 
 ## [0.16.1] - 2024-10-11
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.81.0-alpine AS targetarch
+FROM rust:1.86.0-alpine AS targetarch
 
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
@@ -74,7 +74,7 @@ RUN cd bob_the_builder && \
 #
 # rust-optimizer target
 #
-FROM rust:1.81.0-alpine AS rust-optimizer
+FROM rust:1.86.0-alpine AS rust-optimizer
 
 # Download the crates.io index using the new sparse protocol to improve performance
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse

--- a/optimize.sh
+++ b/optimize.sh
@@ -46,8 +46,7 @@ for WASM in /target/wasm32-unknown-unknown/release/*.wasm; do
 
   OUT_FILENAME=$(basename "$WASM")
   echo "Optimizing $OUT_FILENAME ..."
-  # --signext-lowering is needed to support blockchains runnning CosmWasm < 1.3. It can be removed eventually
-  wasm-opt -Os --signext-lowering "$WASM" -o "artifacts/$OUT_FILENAME"
+  wasm-opt -Os "$WASM" -o "artifacts/$OUT_FILENAME"
 done
 
 echo "Post-processing artifacts..."


### PR DESCRIPTION
supersedes #167

Release will be postponed until CW 3.0 is released.